### PR TITLE
feat(Airtop Node): Add click, type, hover, scrape and load operations

### DIFF
--- a/packages/nodes-base/nodes/Airtop/Airtop.node.ts
+++ b/packages/nodes-base/nodes/Airtop/Airtop.node.ts
@@ -2,6 +2,7 @@ import { NodeConnectionType } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeType, INodeTypeDescription } from 'n8n-workflow';
 
 import * as extraction from './actions/extraction/Extraction.resource';
+import * as interaction from './actions/interaction/Interaction.resource';
 import { router } from './actions/router';
 import * as session from './actions/session/Session.resource';
 import * as window from './actions/window/Window.resource';
@@ -45,12 +46,17 @@ export class Airtop implements INodeType {
 						name: 'Extraction',
 						value: 'extraction',
 					},
+					{
+						name: 'Interaction',
+						value: 'interaction',
+					},
 				],
 				default: 'session',
 			},
 			...session.description,
 			...window.description,
 			...extraction.description,
+			...interaction.description,
 		],
 	};
 

--- a/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
@@ -7,7 +7,33 @@ import {
 	MIN_TIMEOUT_MINUTES,
 	MAX_TIMEOUT_MINUTES,
 } from './constants';
-import type { IAirtopResponse } from './transport/response.type';
+import type { IAirtopResponse } from './transport/types';
+
+/**
+ * Validate a required string field
+ * @param this - The execution context
+ * @param index - The index of the node
+ * @param field - The field to validate
+ * @param fieldName - The name of the field
+ */
+export function validateRequiredStringField(
+	this: IExecuteFunctions,
+	index: number,
+	field: string,
+	fieldName: string,
+) {
+	let value = this.getNodeParameter(field, index) as string;
+	value = (value || '').trim();
+	const errorMessage = ERROR_MESSAGES.REQUIRED_PARAMETER.replace('{{field}}', fieldName);
+
+	if (!value) {
+		throw new NodeOperationError(this.getNode(), errorMessage, {
+			itemIndex: index,
+		});
+	}
+
+	return value;
+}
 
 /**
  * Validate the session ID parameter

--- a/packages/nodes-base/nodes/Airtop/actions/extraction/Extraction.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/extraction/Extraction.resource.ts
@@ -1,8 +1,9 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as getPaginated from './getPaginated.operation';
+import * as scrape from './scrape.operation';
 
-export { getPaginated };
+export { getPaginated, scrape };
 
 export const description: INodeProperties[] = [
 	{
@@ -22,8 +23,15 @@ export const description: INodeProperties[] = [
 				description: 'Get data from a paginated source',
 				action: 'Get paginated data',
 			},
+			{
+				name: 'Scrape',
+				value: 'scrape',
+				description: 'Scrape a window and return the content as markdown',
+				action: 'Scrape window',
+			},
 		],
 		default: 'getPaginated',
 	},
 	...getPaginated.description,
+	...scrape.description,
 ];

--- a/packages/nodes-base/nodes/Airtop/actions/extraction/Extraction.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/extraction/Extraction.resource.ts
@@ -1,9 +1,10 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as getPaginated from './getPaginated.operation';
+import * as query from './query.operation';
 import * as scrape from './scrape.operation';
 
-export { getPaginated, scrape };
+export { getPaginated, query, scrape };
 
 export const description: INodeProperties[] = [
 	{
@@ -24,6 +25,12 @@ export const description: INodeProperties[] = [
 				action: 'Get paginated data',
 			},
 			{
+				name: 'Query Page',
+				value: 'query',
+				description: 'Query the current page content',
+				action: 'Query page',
+			},
+			{
 				name: 'Scrape',
 				value: 'scrape',
 				description: 'Scrape a window and return the content as markdown',
@@ -33,5 +40,6 @@ export const description: INodeProperties[] = [
 		default: 'getPaginated',
 	},
 	...getPaginated.description,
+	...query.description,
 	...scrape.description,
 ];

--- a/packages/nodes-base/nodes/Airtop/actions/extraction/query.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/extraction/query.operation.ts
@@ -9,6 +9,20 @@ import { apiRequest } from '../../transport';
 
 export const description: INodeProperties[] = [
 	{
+		displayName: 'Session ID',
+		name: 'sessionId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['extraction'],
+				operation: ['query'],
+			},
+		},
+		default: '={{ $json["sessionId"] }}',
+		description: 'The ID of the session',
+	},
+	{
 		displayName: 'Window ID',
 		name: 'windowId',
 		type: 'string',
@@ -16,7 +30,7 @@ export const description: INodeProperties[] = [
 		default: '={{ $json["windowId"] }}',
 		displayOptions: {
 			show: {
-				resource: ['window'],
+				resource: ['extraction'],
 				operation: ['query'],
 			},
 		},
@@ -31,9 +45,10 @@ export const description: INodeProperties[] = [
 		},
 		required: true,
 		default: '',
+		placeholder: 'Is there a login modal on this page?',
 		displayOptions: {
 			show: {
-				resource: ['window'],
+				resource: ['extraction'],
 				operation: ['query'],
 			},
 		},
@@ -47,7 +62,7 @@ export const description: INodeProperties[] = [
 		default: {},
 		displayOptions: {
 			show: {
-				resource: ['window'],
+				resource: ['extraction'],
 				operation: ['query'],
 			},
 		},

--- a/packages/nodes-base/nodes/Airtop/actions/extraction/scrape.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/extraction/scrape.operation.ts
@@ -1,0 +1,58 @@
+import {
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeProperties,
+} from 'n8n-workflow';
+
+import { validateSessionAndWindowId, validateAirtopApiResponse } from '../../GenericFunctions';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Session ID',
+		name: 'sessionId',
+		type: 'string',
+		required: true,
+		default: '={{ $json["sessionId"] }}',
+		displayOptions: {
+			show: {
+				resource: ['extraction'],
+				operation: ['scrape'],
+			},
+		},
+		description: 'The ID of the session to use for the scraping',
+	},
+	{
+		displayName: 'Window ID',
+		name: 'windowId',
+		type: 'string',
+		required: true,
+		default: '={{ $json["windowId"] }}',
+		displayOptions: {
+			show: {
+				resource: ['extraction'],
+				operation: ['scrape'],
+			},
+		},
+		description: 'The ID of the window to use for the scraping',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const { sessionId, windowId } = validateSessionAndWindowId.call(this, index);
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/sessions/${sessionId}/windows/${windowId}/scrape-content`,
+		{},
+	);
+
+	// validate response
+	validateAirtopApiResponse(this.getNode(), response);
+
+	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+}

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/Interaction.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/Interaction.resource.ts
@@ -1,0 +1,142 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as click from './click.operation';
+import * as hover from './hover.operation';
+import * as type from './type.operation';
+
+export { click, hover, type };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+			},
+		},
+		options: [
+			{
+				name: 'Click',
+				value: 'click',
+				description: 'Click on an element',
+				action: 'Click on an element',
+			},
+			{
+				name: 'Hover',
+				value: 'hover',
+				description: 'Hover over an element',
+				action: 'Hover over an element',
+			},
+			{
+				name: 'Type',
+				value: 'type',
+				description: 'Type text into an element',
+				action: 'Type text into an element',
+			},
+		],
+		default: 'click',
+	},
+	{
+		displayName: 'Session ID',
+		name: 'sessionId',
+		type: 'string',
+		required: true,
+		default: '={{ $json["sessionId"] }}',
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+			},
+		},
+		description: 'The ID of the session to use for the interaction',
+	},
+	{
+		displayName: 'Window ID',
+		name: 'windowId',
+		type: 'string',
+		required: true,
+		default: '={{ $json["windowId"] }}',
+		description: 'The ID of the window to use for the interaction',
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+			},
+		},
+	},
+	...click.description,
+	...hover.description,
+	...type.description,
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Visual Scope',
+				name: 'visualScope',
+				type: 'options',
+				default: 'auto',
+				description: 'Defines the strategy for visual analysis of the current window',
+				options: [
+					{
+						name: 'Auto',
+						description: 'Provides the simplest out-of-the-box experience for most web pages',
+						value: 'auto',
+					},
+					{
+						name: 'Viewport',
+						description: 'For analysis of the current browser view only',
+						value: 'viewport',
+					},
+					{
+						name: 'Page',
+						description: 'For analysis of the entire page',
+						value: 'page',
+					},
+					{
+						name: 'Scan',
+						description:
+							"For a full page analysis on sites that have compatibility issues with 'Page' mode",
+						value: 'scan',
+					},
+				],
+			},
+			{
+				displayName: 'Wait for Navigation',
+				name: 'waitForNavigation',
+				type: 'options',
+				default: 'load',
+				description:
+					"The condition to wait for the navigation to complete after an interaction (click, type or hover). Defaults to 'Fully Loaded'.",
+				hint: 'Depending on the condition, the execution might be faster or slower.',
+				options: [
+					{
+						name: 'Fully Loaded (Slower)',
+						value: 'load',
+					},
+					{
+						name: 'DOM Only Loaded (Faster)',
+						value: 'domcontentloaded',
+					},
+					{
+						name: 'All Network Activity Has Stopped',
+						value: 'networkidle0',
+					},
+					{
+						name: 'Most Network Activity Has Stopped',
+						value: 'networkidle2',
+					},
+				],
+			},
+		],
+	},
+];

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/click.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/click.operation.ts
@@ -1,0 +1,59 @@
+import {
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeProperties,
+} from 'n8n-workflow';
+
+import { constructInteractionRequest } from './helpers';
+import {
+	validateRequiredStringField,
+	validateSessionAndWindowId,
+	validateAirtopApiResponse,
+} from '../../GenericFunctions';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Element Description',
+		name: 'elementDescription',
+		type: 'string',
+		required: true,
+		default: '',
+		placeholder: 'The login button',
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+				operation: ['click'],
+			},
+		},
+		description: 'The description of the element to click',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const { sessionId, windowId } = validateSessionAndWindowId.call(this, index);
+	const elementDescription = validateRequiredStringField.call(
+		this,
+		index,
+		'elementDescription',
+		'Element Description',
+	);
+
+	const request = constructInteractionRequest.call(this, index, {
+		elementDescription,
+	});
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/sessions/${sessionId}/windows/${windowId}/click`,
+		request,
+	);
+
+	validateAirtopApiResponse(this.getNode(), response);
+
+	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+}

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/helpers.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/helpers.ts
@@ -1,0 +1,31 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import type { IAirtopInteractionRequest } from '../../transport/types';
+
+export function constructInteractionRequest(
+	this: IExecuteFunctions,
+	index: number,
+	parameters: Partial<IAirtopInteractionRequest> = {},
+): IAirtopInteractionRequest {
+	const additionalFields = this.getNodeParameter('additionalFields', index);
+	const request: IAirtopInteractionRequest = {
+		configuration: {},
+	};
+
+	if (additionalFields.visualScope) {
+		request.configuration.visualAnalysis = {
+			scope: additionalFields.visualScope as string,
+		};
+	}
+
+	if (additionalFields.waitForNavigation) {
+		request.waitForNavigation = true;
+		request.configuration.waitForNavigationConfig = {
+			waitUntil: additionalFields.waitForNavigation as string,
+		};
+	}
+
+	Object.assign(request, parameters);
+
+	return request;
+}

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/hover.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/hover.operation.ts
@@ -1,0 +1,59 @@
+import {
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeProperties,
+} from 'n8n-workflow';
+
+import { constructInteractionRequest } from './helpers';
+import {
+	validateRequiredStringField,
+	validateSessionAndWindowId,
+	validateAirtopApiResponse,
+} from '../../GenericFunctions';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Element Description',
+		name: 'elementDescription',
+		type: 'string',
+		required: true,
+		default: '',
+		placeholder: 'the user profile image',
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+				operation: ['hover'],
+			},
+		},
+		description: 'The description of the element to hover over',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const { sessionId, windowId } = validateSessionAndWindowId.call(this, index);
+	const elementDescription = validateRequiredStringField.call(
+		this,
+		index,
+		'elementDescription',
+		'Element Description',
+	);
+
+	const request = constructInteractionRequest.call(this, index, {
+		elementDescription,
+	});
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/sessions/${sessionId}/windows/${windowId}/hover`,
+		request,
+	);
+
+	validateAirtopApiResponse(this.getNode(), response);
+
+	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+}

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/type.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/type.operation.ts
@@ -1,0 +1,85 @@
+import {
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeProperties,
+} from 'n8n-workflow';
+
+import { constructInteractionRequest } from './helpers';
+import {
+	validateRequiredStringField,
+	validateSessionAndWindowId,
+	validateAirtopApiResponse,
+} from '../../GenericFunctions';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Text',
+		name: 'text',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+				operation: ['type'],
+			},
+		},
+		description: 'The text to type into the browser window',
+	},
+	{
+		displayName: 'Press Enter Key',
+		name: 'pressEnterKey',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to press the Enter key after typing the text',
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+				operation: ['type'],
+			},
+		},
+	},
+	{
+		displayName: 'Element Description',
+		name: 'elementDescription',
+		type: 'string',
+		default: '',
+		placeholder: 'the search box',
+		description: 'The description of the element to type into',
+		hint: "Describe the element, e.g. 'the search box', 'username field', 'password field'",
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+				operation: ['type'],
+			},
+		},
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const { sessionId, windowId } = validateSessionAndWindowId.call(this, index);
+	const text = validateRequiredStringField.call(this, index, 'text', 'Text');
+	const pressEnterKey = this.getNodeParameter('pressEnterKey', index) as boolean;
+	const elementDescription = this.getNodeParameter('elementDescription', index) as string;
+
+	const request = constructInteractionRequest.call(this, index, {
+		text,
+		pressEnterKey,
+		elementDescription,
+	});
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/sessions/${sessionId}/windows/${windowId}/type`,
+		request,
+	);
+
+	validateAirtopApiResponse(this.getNode(), response);
+
+	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+}

--- a/packages/nodes-base/nodes/Airtop/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/node.type.ts
@@ -2,8 +2,9 @@ import type { AllEntities } from 'n8n-workflow';
 
 type NodeMap = {
 	session: 'create' | 'terminate';
-	window: 'create' | 'close' | 'getScreenshot' | 'query';
+	window: 'create' | 'close' | 'getScreenshot' | 'load' | 'query';
 	extraction: 'getPaginated';
+	interaction: 'click' | 'hover' | 'type';
 };
 
 export type AirtopType = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Airtop/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/node.type.ts
@@ -2,8 +2,8 @@ import type { AllEntities } from 'n8n-workflow';
 
 type NodeMap = {
 	session: 'create' | 'terminate';
-	window: 'create' | 'close' | 'getScreenshot' | 'load' | 'query';
-	extraction: 'getPaginated';
+	window: 'create' | 'close' | 'getScreenshot' | 'load';
+	extraction: 'getPaginated' | 'query' | 'scrape';
 	interaction: 'click' | 'hover' | 'type';
 };
 

--- a/packages/nodes-base/nodes/Airtop/actions/router.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/router.ts
@@ -2,6 +2,7 @@ import type { IDataObject, IExecuteFunctions, INodeExecutionData } from 'n8n-wor
 import { NodeOperationError } from 'n8n-workflow';
 
 import * as extraction from './extraction/Extraction.resource';
+import * as interaction from './interaction/Interaction.resource';
 import type { AirtopType } from './node.type';
 import * as session from './session/Session.resource';
 import * as window from './window/Window.resource';
@@ -27,6 +28,9 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 					break;
 				case 'window':
 					responseData = await window[airtopNodeData.operation].execute.call(this, i);
+					break;
+				case 'interaction':
+					responseData = await interaction[airtopNodeData.operation].execute.call(this, i);
 					break;
 				case 'extraction':
 					responseData = await extraction[airtopNodeData.operation].execute.call(this, i);

--- a/packages/nodes-base/nodes/Airtop/actions/window/Window.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/Window.resource.ts
@@ -4,9 +4,8 @@ import * as close from './close.operation';
 import * as create from './create.operation';
 import * as getScreenshot from './getScreenshot.operation';
 import * as load from './load.operation';
-import * as query from './query.operation';
 
-export { create, close, getScreenshot, load, query };
+export { create, close, getScreenshot, load };
 
 export const description: INodeProperties[] = [
 	{
@@ -44,12 +43,6 @@ export const description: INodeProperties[] = [
 				description: 'Load a page in the window',
 				action: 'Load a page',
 			},
-			{
-				name: 'Query Page',
-				value: 'query',
-				description: 'Query the current page content',
-				action: 'Query page',
-			},
 		],
 		default: 'create',
 	},
@@ -70,5 +63,4 @@ export const description: INodeProperties[] = [
 	...create.description,
 	...getScreenshot.description,
 	...load.description,
-	...query.description,
 ];

--- a/packages/nodes-base/nodes/Airtop/actions/window/Window.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/Window.resource.ts
@@ -3,9 +3,10 @@ import type { INodeProperties } from 'n8n-workflow';
 import * as close from './close.operation';
 import * as create from './create.operation';
 import * as getScreenshot from './getScreenshot.operation';
+import * as load from './load.operation';
 import * as query from './query.operation';
 
-export { create, close, getScreenshot, query };
+export { create, close, getScreenshot, load, query };
 
 export const description: INodeProperties[] = [
 	{
@@ -20,6 +21,12 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{
+				name: 'Close',
+				value: 'close',
+				description: 'Close a window',
+				action: 'Close a window',
+			},
+			{
 				name: 'Create',
 				value: 'create',
 				description: 'Create a new window',
@@ -32,16 +39,16 @@ export const description: INodeProperties[] = [
 				action: 'Get screenshot',
 			},
 			{
+				name: 'Load URL',
+				value: 'load',
+				description: 'Load a page in the window',
+				action: 'Load a page',
+			},
+			{
 				name: 'Query Page',
 				value: 'query',
 				description: 'Query the current page content',
 				action: 'Query page',
-			},
-			{
-				name: 'Close',
-				value: 'close',
-				description: 'Close a window',
-				action: 'Close a window',
 			},
 		],
 		default: 'create',
@@ -59,8 +66,9 @@ export const description: INodeProperties[] = [
 		default: '={{ $json["sessionId"] }}',
 		description: 'The ID of the session',
 	},
+	...close.description,
 	...create.description,
 	...getScreenshot.description,
+	...load.description,
 	...query.description,
-	...close.description,
 ];

--- a/packages/nodes-base/nodes/Airtop/actions/window/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/create.operation.ts
@@ -8,7 +8,7 @@ import { NodeApiError } from 'n8n-workflow';
 
 import { validateAirtopApiResponse, validateSessionId, validateUrl } from '../../GenericFunctions';
 import { apiRequest } from '../../transport';
-import type { IAirtopResponse } from '../../transport/response.type';
+import type { IAirtopResponse } from '../../transport/types';
 
 export const description: INodeProperties[] = [
 	{
@@ -16,6 +16,7 @@ export const description: INodeProperties[] = [
 		name: 'url',
 		type: 'string',
 		default: '',
+		placeholder: 'https://google.com',
 		description: 'Initial URL to load in the window. Defaults to http://google.com.',
 		displayOptions: {
 			show: {
@@ -30,6 +31,19 @@ export const description: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		description: "Whether to get the URL of the window's live view",
+		displayOptions: {
+			show: {
+				resource: ['window'],
+				operation: ['create'],
+			},
+		},
+	},
+	{
+		displayName: 'Disable Resize',
+		name: 'disableResize',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to disable the window from being resized in the Live View',
 		displayOptions: {
 			show: {
 				resource: ['window'],
@@ -91,6 +105,7 @@ export async function execute(
 	const url = validateUrl.call(this, index);
 	const additionalFields = this.getNodeParameter('additionalFields', index);
 	const getLiveView = this.getNodeParameter('getLiveView', index, false);
+	const disableResize = this.getNodeParameter('disableResize', index, false);
 
 	let response: IAirtopResponse;
 
@@ -111,7 +126,13 @@ export async function execute(
 	const windowId = String(response.data.windowId);
 
 	if (getLiveView) {
-		response = await apiRequest.call(this, 'GET', `/sessions/${sessionId}/windows/${windowId}`);
+		response = await apiRequest.call(
+			this,
+			'GET',
+			`/sessions/${sessionId}/windows/${windowId}`,
+			undefined,
+			{ disableResize },
+		);
 	}
 
 	// validate response

--- a/packages/nodes-base/nodes/Airtop/actions/window/load.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/load.operation.ts
@@ -1,0 +1,112 @@
+import {
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeProperties,
+} from 'n8n-workflow';
+
+import {
+	validateRequiredStringField,
+	validateSessionAndWindowId,
+	validateUrl,
+	validateAirtopApiResponse,
+} from '../../GenericFunctions';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Window ID',
+		name: 'windowId',
+		type: 'string',
+		required: true,
+		default: '={{ $json["windowId"] }}',
+		displayOptions: {
+			show: {
+				resource: ['window'],
+				operation: ['load'],
+			},
+		},
+	},
+	{
+		displayName: 'URL',
+		name: 'url',
+		type: 'string',
+		required: true,
+		default: '',
+		placeholder: 'https://google.com',
+		displayOptions: {
+			show: {
+				resource: ['window'],
+				operation: ['load'],
+			},
+		},
+		description: 'The URL to load in the window',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['window'],
+				operation: ['load'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Wait Until',
+				name: 'waitUntil',
+				type: 'options',
+				default: 'load',
+				description: "Wait until the specified loading event occurs. Defaults to 'Fully Loaded'.",
+				options: [
+					{
+						name: 'Complete',
+						value: 'complete',
+						description: "Wait until the page and all it's iframes have loaded it's dom and assets",
+					},
+					{
+						name: 'DOM Only Loaded',
+						value: 'domContentLoaded',
+						description: 'Wait until the dom has loaded',
+					},
+					{
+						name: 'Fully Loaded',
+						value: 'load',
+						description: "Wait until the page dom and it's assets have loaded",
+					},
+					{
+						name: 'No Wait',
+						value: 'noWait',
+						description: 'Do not wait for any loading event and will return immediately',
+					},
+				],
+			},
+		],
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const { sessionId, windowId } = validateSessionAndWindowId.call(this, index);
+	let url = validateRequiredStringField.call(this, index, 'url', 'URL');
+	url = validateUrl.call(this, index);
+	const additionalFields = this.getNodeParameter('additionalFields', index);
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/sessions/${sessionId}/windows/${windowId}`,
+		{
+			url,
+			waitUntil: additionalFields.waitUntil,
+		},
+	);
+
+	validateAirtopApiResponse(this.getNode(), response);
+
+	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+}

--- a/packages/nodes-base/nodes/Airtop/constants.ts
+++ b/packages/nodes-base/nodes/Airtop/constants.ts
@@ -13,4 +13,5 @@ export const ERROR_MESSAGES = {
 	TIMEOUT_MINUTES_INVALID: `Timeout must be between ${MIN_TIMEOUT_MINUTES} and ${MAX_TIMEOUT_MINUTES} minutes`,
 	URL_INVALID: "'URL' must start with 'http' or 'https'",
 	PROFILE_NAME_REQUIRED: "'Profile Name' is required when 'Save Profile' is enabled",
+	REQUIRED_PARAMETER: "Please fill the '{{field}}' parameter",
 };

--- a/packages/nodes-base/nodes/Airtop/test/node/extraction/query.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/extraction/query.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import * as query from '../../../actions/window/query.operation';
+import * as query from '../../../actions/extraction/query.operation';
 import { ERROR_MESSAGES } from '../../../constants';
 import * as transport from '../../../transport';
 import { createMockExecuteFunction } from '../helpers';

--- a/packages/nodes-base/nodes/Airtop/test/node/extraction/scrape.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/extraction/scrape.test.ts
@@ -1,0 +1,91 @@
+import nock from 'nock';
+
+import * as scrape from '../../../actions/extraction/scrape.operation';
+import { ERROR_MESSAGES } from '../../../constants';
+import * as transport from '../../../transport';
+import { createMockExecuteFunction } from '../helpers';
+
+const baseNodeParameters = {
+	resource: 'extraction',
+	operation: 'scrape',
+	sessionId: 'test-session-123',
+	windowId: 'win-123',
+};
+
+const mockResponse = {
+	data: {
+		content: '<html><body>Scraped content</body></html>',
+	},
+};
+
+jest.mock('../../../transport', () => {
+	const originalModule = jest.requireActual<typeof transport>('../../../transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async function () {
+			return {
+				status: 'success',
+				data: mockResponse.data,
+			};
+		}),
+	};
+});
+
+describe('Test Airtop, scrape operation', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+		jest.unmock('../../../transport');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should scrape content successfully', async () => {
+		const result = await scrape.execute.call(createMockExecuteFunction(baseNodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/scrape-content',
+			{},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: 'test-session-123',
+					windowId: 'win-123',
+					status: 'success',
+					data: mockResponse.data,
+				},
+			},
+		]);
+	});
+
+	it('should throw error when sessionId is empty', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			sessionId: '',
+		};
+
+		await expect(scrape.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			ERROR_MESSAGES.SESSION_ID_REQUIRED,
+		);
+	});
+
+	it('should throw error when windowId is empty', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			windowId: '',
+		};
+
+		await expect(scrape.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			ERROR_MESSAGES.WINDOW_ID_REQUIRED,
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Airtop/test/node/interaction/click.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/interaction/click.test.ts
@@ -1,0 +1,137 @@
+import nock from 'nock';
+
+import * as click from '../../../actions/interaction/click.operation';
+import { ERROR_MESSAGES } from '../../../constants';
+import * as transport from '../../../transport';
+import { createMockExecuteFunction } from '../helpers';
+
+const baseNodeParameters = {
+	resource: 'interaction',
+	operation: 'click',
+	sessionId: 'test-session-123',
+	windowId: 'win-123',
+	elementDescription: 'the login button',
+	additionalFields: {},
+};
+
+const mockResponse = {
+	success: true,
+	message: 'Click executed successfully',
+};
+
+jest.mock('../../../transport', () => {
+	const originalModule = jest.requireActual<typeof transport>('../../../transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async function () {
+			return {
+				status: 'success',
+				data: mockResponse,
+			};
+		}),
+	};
+});
+
+describe('Test Airtop, click operation', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+		jest.unmock('../../../transport');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should execute click with minimal parameters', async () => {
+		const result = await click.execute.call(createMockExecuteFunction(baseNodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/click',
+			{
+				elementDescription: 'the login button',
+				configuration: {},
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: baseNodeParameters.sessionId,
+					windowId: baseNodeParameters.windowId,
+					status: 'success',
+					data: mockResponse,
+				},
+			},
+		]);
+	});
+
+	it("should throw error when 'elementDescription' parameter is empty", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			elementDescription: '',
+		};
+		const errorMessage = ERROR_MESSAGES.REQUIRED_PARAMETER.replace(
+			'{{field}}',
+			'Element Description',
+		);
+
+		await expect(click.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			errorMessage,
+		);
+	});
+
+	it("should include 'visualScope' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				visualScope: 'viewport',
+			},
+		};
+
+		await click.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/click',
+			{
+				configuration: {
+					visualAnalysis: {
+						scope: 'viewport',
+					},
+				},
+				elementDescription: 'the login button',
+			},
+		);
+	});
+
+	it("should include 'waitForNavigation' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				waitForNavigation: 'load',
+			},
+		};
+
+		await click.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/click',
+			{
+				configuration: {
+					waitForNavigationConfig: {
+						waitUntil: 'load',
+					},
+				},
+				waitForNavigation: true,
+				elementDescription: 'the login button',
+			},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Airtop/test/node/interaction/helpers.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/interaction/helpers.test.ts
@@ -1,0 +1,77 @@
+import { constructInteractionRequest } from '../../../actions/interaction/helpers';
+import { createMockExecuteFunction } from '../helpers';
+
+describe('Test Airtop interaction helpers', () => {
+	describe('constructInteractionRequest', () => {
+		it('should construct basic request with default values', () => {
+			const mockExecute = createMockExecuteFunction({
+				additionalFields: {},
+			});
+
+			const request = constructInteractionRequest.call(mockExecute, 0);
+
+			expect(request).toEqual({
+				configuration: {},
+			});
+		});
+
+		it("should include 'visualScope' parameter when specified", () => {
+			const mockExecute = createMockExecuteFunction({
+				additionalFields: {
+					visualScope: 'viewport',
+				},
+			});
+
+			const request = constructInteractionRequest.call(mockExecute, 0);
+
+			expect(request).toEqual({
+				configuration: {
+					visualAnalysis: {
+						scope: 'viewport',
+					},
+				},
+			});
+		});
+
+		it("should include 'waitForNavigation' parameter when specified", () => {
+			const mockExecute = createMockExecuteFunction({
+				additionalFields: {
+					waitForNavigation: 'load',
+				},
+			});
+
+			const request = constructInteractionRequest.call(mockExecute, 0);
+
+			expect(request).toEqual({
+				configuration: {
+					waitForNavigationConfig: {
+						waitUntil: 'load',
+					},
+				},
+				waitForNavigation: true,
+			});
+		});
+
+		it('should merge additional parameters', () => {
+			const mockExecute = createMockExecuteFunction({
+				additionalFields: {
+					waitForNavigation: 'load',
+				},
+			});
+
+			const request = constructInteractionRequest.call(mockExecute, 0, {
+				elementDescription: 'test element',
+			});
+
+			expect(request).toEqual({
+				configuration: {
+					waitForNavigationConfig: {
+						waitUntil: 'load',
+					},
+				},
+				waitForNavigation: true,
+				elementDescription: 'test element',
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Airtop/test/node/interaction/hover.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/interaction/hover.test.ts
@@ -1,0 +1,137 @@
+import nock from 'nock';
+
+import * as hover from '../../../actions/interaction/hover.operation';
+import { ERROR_MESSAGES } from '../../../constants';
+import * as transport from '../../../transport';
+import { createMockExecuteFunction } from '../helpers';
+
+const baseNodeParameters = {
+	resource: 'interaction',
+	operation: 'hover',
+	sessionId: 'test-session-123',
+	windowId: 'win-123',
+	elementDescription: 'the user profile image',
+	additionalFields: {},
+};
+
+const mockResponse = {
+	success: true,
+	message: 'Hover interaction executed successfully',
+};
+
+jest.mock('../../../transport', () => {
+	const originalModule = jest.requireActual<typeof transport>('../../../transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async function () {
+			return {
+				status: 'success',
+				data: mockResponse,
+			};
+		}),
+	};
+});
+
+describe('Test Airtop, hover operation', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+		jest.unmock('../../../transport');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should execute hover with minimal parameters', async () => {
+		const result = await hover.execute.call(createMockExecuteFunction(baseNodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/hover',
+			{
+				configuration: {},
+				elementDescription: 'the user profile image',
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: 'test-session-123',
+					windowId: 'win-123',
+					status: 'success',
+					data: mockResponse,
+				},
+			},
+		]);
+	});
+
+	it("should throw error when 'elementDescription' parameter is empty", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			elementDescription: '',
+		};
+		const errorMessage = ERROR_MESSAGES.REQUIRED_PARAMETER.replace(
+			'{{field}}',
+			'Element Description',
+		);
+
+		await expect(hover.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			errorMessage,
+		);
+	});
+
+	it("should include 'visualScope' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				visualScope: 'viewport',
+			},
+		};
+
+		await hover.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/hover',
+			{
+				configuration: {
+					visualAnalysis: {
+						scope: 'viewport',
+					},
+				},
+				elementDescription: 'the user profile image',
+			},
+		);
+	});
+
+	it("should include 'waitForNavigation' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				waitForNavigation: 'load',
+			},
+		};
+
+		await hover.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/hover',
+			{
+				configuration: {
+					waitForNavigationConfig: {
+						waitUntil: 'load',
+					},
+				},
+				waitForNavigation: true,
+				elementDescription: 'the user profile image',
+			},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Airtop/test/node/interaction/type.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/interaction/type.test.ts
@@ -1,0 +1,181 @@
+import nock from 'nock';
+
+import * as type from '../../../actions/interaction/type.operation';
+import { ERROR_MESSAGES } from '../../../constants';
+import * as transport from '../../../transport';
+import { createMockExecuteFunction } from '../helpers';
+
+const baseNodeParameters = {
+	resource: 'interaction',
+	operation: 'type',
+	sessionId: 'test-session-123',
+	windowId: 'win-123',
+	text: 'Hello World',
+	pressEnterKey: false,
+	elementDescription: '',
+	additionalFields: {},
+};
+
+const mockResponse = {
+	success: true,
+	message: 'Text typed successfully',
+};
+
+jest.mock('../../../transport', () => {
+	const originalModule = jest.requireActual<typeof transport>('../../../transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async function () {
+			return {
+				status: 'success',
+				data: mockResponse,
+			};
+		}),
+	};
+});
+
+describe('Test Airtop, type operation', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+		jest.unmock('../../../transport');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should execute type with minimal parameters', async () => {
+		const result = await type.execute.call(createMockExecuteFunction(baseNodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/type',
+			{
+				configuration: {},
+				text: 'Hello World',
+				pressEnterKey: false,
+				elementDescription: '',
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: baseNodeParameters.sessionId,
+					windowId: baseNodeParameters.windowId,
+					status: 'success',
+					data: mockResponse,
+				},
+			},
+		]);
+	});
+
+	it("should throw error when 'text' parameter is empty", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			text: '',
+		};
+
+		await expect(type.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			ERROR_MESSAGES.REQUIRED_PARAMETER.replace('{{field}}', 'Text'),
+		);
+	});
+
+	it("should include 'elementDescription' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			elementDescription: 'the search box',
+		};
+
+		await type.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/type',
+			{
+				configuration: {},
+				text: 'Hello World',
+				pressEnterKey: false,
+				elementDescription: 'the search box',
+			},
+		);
+	});
+
+	it("should include 'pressEnterKey' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			pressEnterKey: true,
+		};
+
+		await type.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/type',
+			{
+				configuration: {},
+				text: 'Hello World',
+				pressEnterKey: true,
+				elementDescription: '',
+			},
+		);
+	});
+
+	it("should include 'waitForNavigation' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				waitForNavigation: 'load',
+			},
+		};
+
+		await type.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/type',
+			{
+				configuration: {
+					waitForNavigationConfig: {
+						waitUntil: 'load',
+					},
+				},
+				waitForNavigation: true,
+				text: 'Hello World',
+				pressEnterKey: false,
+				elementDescription: '',
+			},
+		);
+	});
+
+	it("should include 'visualScope' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				visualScope: 'viewport',
+			},
+		};
+
+		await type.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/type',
+			{
+				configuration: {
+					visualAnalysis: {
+						scope: 'viewport',
+					},
+				},
+				text: 'Hello World',
+				pressEnterKey: false,
+				elementDescription: '',
+			},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Airtop/test/node/window/load.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/window/load.test.ts
@@ -1,0 +1,115 @@
+import nock from 'nock';
+
+import * as load from '../../../actions/window/load.operation';
+import { ERROR_MESSAGES } from '../../../constants';
+import * as transport from '../../../transport';
+import { createMockExecuteFunction } from '../helpers';
+
+const baseNodeParameters = {
+	resource: 'window',
+	operation: 'load',
+	sessionId: 'test-session-123',
+	windowId: 'win-123',
+	url: 'https://example.com',
+	additionalFields: {},
+};
+
+const mockResponse = {
+	success: true,
+	message: 'Page loaded successfully',
+};
+
+jest.mock('../../../transport', () => {
+	const originalModule = jest.requireActual<typeof transport>('../../../transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async function () {
+			return {
+				status: 'success',
+				data: mockResponse,
+			};
+		}),
+	};
+});
+
+describe('Test Airtop, window load operation', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+		jest.unmock('../../../transport');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should load URL with minimal parameters', async () => {
+		const result = await load.execute.call(createMockExecuteFunction(baseNodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123',
+			{
+				url: 'https://example.com',
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: baseNodeParameters.sessionId,
+					windowId: baseNodeParameters.windowId,
+					status: 'success',
+					data: mockResponse,
+				},
+			},
+		]);
+	});
+
+	it('should throw error when URL is empty', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			url: '',
+		};
+		const errorMessage = ERROR_MESSAGES.REQUIRED_PARAMETER.replace('{{field}}', 'URL');
+
+		await expect(load.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			errorMessage,
+		);
+	});
+
+	it('should throw error when URL is invalid', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			url: 'not-a-valid-url',
+		};
+
+		await expect(load.execute.call(createMockExecuteFunction(nodeParameters), 0)).rejects.toThrow(
+			ERROR_MESSAGES.URL_INVALID,
+		);
+	});
+
+	it("should include 'waitUntil' parameter when specified", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				waitUntil: 'domContentLoaded',
+			},
+		};
+
+		await load.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123',
+			{
+				url: 'https://example.com',
+				waitUntil: 'domContentLoaded',
+			},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Airtop/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/utils.test.ts
@@ -10,9 +10,70 @@ import {
 	validateAirtopApiResponse,
 	validateSessionId,
 	validateUrl,
+	validateRequiredStringField,
 } from '../GenericFunctions';
 
 describe('Test Airtop utils', () => {
+	describe('validateRequiredStringField', () => {
+		it('should validate non-empty string field', () => {
+			const nodeParameters = {
+				testField: 'test-value',
+			};
+
+			const result = validateRequiredStringField.call(
+				createMockExecuteFunction(nodeParameters),
+				0,
+				'testField',
+				'Test Field',
+			);
+			expect(result).toBe('test-value');
+		});
+
+		it('should trim whitespace from string field', () => {
+			const nodeParameters = {
+				testField: '  test-value  ',
+			};
+
+			const result = validateRequiredStringField.call(
+				createMockExecuteFunction(nodeParameters),
+				0,
+				'testField',
+				'Test Field',
+			);
+			expect(result).toBe('test-value');
+		});
+
+		it('should throw error for empty string field', () => {
+			const nodeParameters = {
+				testField: '',
+			};
+
+			expect(() =>
+				validateRequiredStringField.call(
+					createMockExecuteFunction(nodeParameters),
+					0,
+					'testField',
+					'Test Field',
+				),
+			).toThrow(ERROR_MESSAGES.REQUIRED_PARAMETER.replace('{{field}}', 'Test Field'));
+		});
+
+		it('should throw error for whitespace-only string field', () => {
+			const nodeParameters = {
+				testField: '   ',
+			};
+
+			expect(() =>
+				validateRequiredStringField.call(
+					createMockExecuteFunction(nodeParameters),
+					0,
+					'testField',
+					'Test Field',
+				),
+			).toThrow(ERROR_MESSAGES.REQUIRED_PARAMETER.replace('{{field}}', 'Test Field'));
+		});
+	});
+
 	describe('validateProfileName', () => {
 		it('should validate valid profile names', () => {
 			const nodeParameters = {

--- a/packages/nodes-base/nodes/Airtop/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtop/transport/index.ts
@@ -6,7 +6,7 @@ import type {
 	IHttpRequestOptions,
 } from 'n8n-workflow';
 
-import type { IAirtopResponse } from './response.type';
+import type { IAirtopResponse } from './types';
 import { BASE_URL } from '../constants';
 
 export async function apiRequest(

--- a/packages/nodes-base/nodes/Airtop/transport/response.type.ts
+++ b/packages/nodes-base/nodes/Airtop/transport/response.type.ts
@@ -1,9 +1,0 @@
-import type { IDataObject } from 'n8n-workflow';
-
-export interface IAirtopResponse extends IDataObject {
-	sessionId?: string;
-	data: IDataObject;
-	meta: IDataObject;
-	errors: IDataObject[];
-	warnings: IDataObject[];
-}

--- a/packages/nodes-base/nodes/Airtop/transport/types.ts
+++ b/packages/nodes-base/nodes/Airtop/transport/types.ts
@@ -1,0 +1,24 @@
+import type { IDataObject } from 'n8n-workflow';
+
+export interface IAirtopResponse extends IDataObject {
+	sessionId?: string;
+	data: IDataObject;
+	meta: IDataObject;
+	errors: IDataObject[];
+	warnings: IDataObject[];
+}
+
+export interface IAirtopInteractionRequest extends IDataObject {
+	text?: string;
+	waitForNavigation?: boolean;
+	elementDescription?: string;
+	pressEnterKey?: boolean;
+	configuration: {
+		visualAnalysis?: {
+			scope: string;
+		};
+		waitForNavigationConfig?: {
+			waitUntil: string;
+		};
+	};
+}


### PR DESCRIPTION
## Summary

Adding more operations to the Airtop node:
 - Interaction: click, type, hover
 - Extraction: scrape
 - Window: load

#### Workflow tested

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/12e8fb0a-158a-4116-a73b-9483b4f2afd9" />


#### Unit tests  ✅

<img width="571" alt="image" src="https://github.com/user-attachments/assets/31445d3a-3136-4de0-8e3e-abb2944e541f" />
<img width="634" alt="image" src="https://github.com/user-attachments/assets/1b3c588a-b374-4d71-8ca7-216131028df0" />



## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
