### PR TITLE
feat(Airtop Node): Optionally create a sesssion for extraction operations (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Airtop/Airtop.node.ts
+++ b/packages/nodes-base/nodes/Airtop/Airtop.node.ts
@@ -1,12 +1,12 @@
 import { NodeConnectionType } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeType, INodeTypeDescription } from 'n8n-workflow';
 
+import { autoTerminateSessionHint } from './actions/common/fields';
 import * as extraction from './actions/extraction/Extraction.resource';
 import * as interaction from './actions/interaction/Interaction.resource';
 import { router } from './actions/router';
 import * as session from './actions/session/Session.resource';
 import * as window from './actions/window/Window.resource';
-
 export class Airtop implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Airtop',
@@ -27,6 +27,7 @@ export class Airtop implements INodeType {
 				required: true,
 			},
 		],
+		hints: [autoTerminateSessionHint],
 		properties: [
 			{
 				displayName: 'Resource',

--- a/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
@@ -1,6 +1,7 @@
 import { NodeApiError, type IExecuteFunctions, type INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
+import { SESSION_MODE } from './actions/common/fields';
 import {
 	ERROR_MESSAGES,
 	DEFAULT_TIMEOUT_MINUTES,
@@ -203,7 +204,7 @@ export function validateAirtopApiResponse(node: INode, response: IAirtopResponse
  */
 export function shouldCreateNewSession(this: IExecuteFunctions, index: number) {
 	const sessionMode = this.getNodeParameter('sessionMode', index) as string;
-	return Boolean(sessionMode && sessionMode === 'new');
+	return Boolean(sessionMode && sessionMode === SESSION_MODE.NEW);
 }
 
 /**

--- a/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
@@ -6,7 +6,9 @@ import {
 	DEFAULT_TIMEOUT_MINUTES,
 	MIN_TIMEOUT_MINUTES,
 	MAX_TIMEOUT_MINUTES,
+	INTEGRATION_URL,
 } from './constants';
+import { apiRequest } from './transport';
 import type { IAirtopResponse } from './transport/types';
 
 /**
@@ -191,4 +193,59 @@ export function validateAirtopApiResponse(node: INode, response: IAirtopResponse
 			message: errorMessage,
 		});
 	}
+}
+
+/**
+ * Check if a new session should be created
+ * @param this - The execution context
+ * @param index - The index of the node
+ * @returns True if a new session should be created, false otherwise
+ */
+export function shouldCreateNewSession(this: IExecuteFunctions, index: number) {
+	const sessionMode = this.getNodeParameter('sessionMode', index) as string;
+	return Boolean(sessionMode && sessionMode === 'new');
+}
+
+/**
+ * Create a new session and window
+ * @param this - The execution context
+ * @param index - The index of the node
+ * @returns The session ID and window ID
+ */
+export async function createSessionAndWindow(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<{ sessionId: string; windowId: string }> {
+	const node = this.getNode();
+	const noCodeEndpoint = `${INTEGRATION_URL}/create-session`;
+	const profileName = validateProfileName.call(this, index);
+	const url = validateRequiredStringField.call(this, index, 'url', 'URL');
+
+	const { sessionId } = await apiRequest.call(this, 'POST', noCodeEndpoint, {
+		configuration: {
+			profileName,
+		},
+	});
+
+	if (!sessionId) {
+		throw new NodeApiError(node, {
+			message: 'Failed to create session',
+			code: 500,
+		});
+	}
+	this.logger.info(`[${node.name}] Session successfully created.`);
+
+	const windowResponse = await apiRequest.call(this, 'POST', `/sessions/${sessionId}/windows`, {
+		url,
+	});
+	const windowId = windowResponse?.data?.windowId as string;
+
+	if (!windowId) {
+		throw new NodeApiError(node, {
+			message: 'Failed to create window',
+			code: 500,
+		});
+	}
+	this.logger.info(`[${node.name}] Window successfully created.`);
+	return { sessionId, windowId };
 }

--- a/packages/nodes-base/nodes/Airtop/actions/common/fields.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/common/fields.ts
@@ -40,7 +40,7 @@ export const urlField: INodeProperties = {
 	type: 'string',
 	default: '',
 	placeholder: 'https://google.com',
-	description: 'Initial URL to load in the window',
+	description: 'URL to load in the window',
 };
 
 export const autoTerminateSessionHint: NodeHint = {
@@ -63,11 +63,11 @@ export function getSessionModeFields(resource: string, operations: string[]): IN
 			description: 'Choose between creating a new session or using an existing one',
 			options: [
 				{
-					name: 'Automatically Create a New Session',
+					name: 'Automatically Create Session',
 					value: SESSION_MODE.NEW,
 				},
 				{
-					name: 'Use an Existing Session',
+					name: 'Use Existing Session',
 					value: SESSION_MODE.EXISTING,
 				},
 			],

--- a/packages/nodes-base/nodes/Airtop/actions/common/fields.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/common/fields.ts
@@ -1,0 +1,132 @@
+import type { INodeProperties, NodeHint } from 'n8n-workflow';
+
+export const SESSION_MODE = {
+	NEW: 'new',
+	EXISTING: 'existing',
+} as const;
+
+export const sessionIdField: INodeProperties = {
+	displayName: 'Session ID',
+	name: 'sessionId',
+	type: 'string',
+	required: true,
+	default: '={{ $json["sessionId"] }}',
+	description:
+		'The ID of the <a href="https://docs.airtop.ai/guides/how-to/creating-a-session" target="_blank">Session</a> to use',
+};
+
+export const windowIdField: INodeProperties = {
+	displayName: 'Window ID',
+	name: 'windowId',
+	type: 'string',
+	required: true,
+	default: '={{ $json["windowId"] }}',
+	description:
+		'The ID of the <a href="https://docs.airtop.ai/guides/how-to/creating-a-session#windows" target="_blank">Window</a> to use',
+};
+
+export const profileNameField: INodeProperties = {
+	displayName: 'Profile Name',
+	name: 'profileName',
+	type: 'string',
+	default: '',
+	description:
+		'The name of the <a href="https://docs.airtop.ai/guides/how-to/saving-a-profile" target="_blank">Profile</a> to load or create',
+};
+
+export const urlField: INodeProperties = {
+	displayName: 'URL',
+	name: 'url',
+	type: 'string',
+	default: '',
+	placeholder: 'https://google.com',
+	description: 'Initial URL to load in the window',
+};
+
+export const autoTerminateSessionHint: NodeHint = {
+	displayCondition:
+		'={{ $parameter["sessionMode"] === "new" && $parameter["autoTerminateSession"] === false }}',
+	message:
+		"When 'Auto-Terminate Session' is disabled, you must manually terminate sessions. By default, idle sessions timeout after 10 minutes",
+	type: 'warning',
+	location: 'outputPane',
+	whenToDisplay: 'beforeExecution',
+};
+
+export function getSessionModeFields(resource: string, operations: string[]): INodeProperties[] {
+	return [
+		{
+			displayName: 'Session Mode',
+			name: 'sessionMode',
+			type: 'options',
+			default: 'existing',
+			description: 'Choose between creating a new session or using an existing one',
+			options: [
+				{
+					name: 'Automatically Create a New Session',
+					value: SESSION_MODE.NEW,
+				},
+				{
+					name: 'Use an Existing Session',
+					value: SESSION_MODE.EXISTING,
+				},
+			],
+			displayOptions: {
+				show: {
+					resource: [resource],
+					operation: operations,
+				},
+			},
+		},
+		{
+			...sessionIdField,
+			displayOptions: {
+				show: {
+					resource: [resource],
+					sessionMode: [SESSION_MODE.EXISTING],
+				},
+			},
+		},
+		{
+			...windowIdField,
+			displayOptions: {
+				show: {
+					resource: [resource],
+					sessionMode: [SESSION_MODE.EXISTING],
+				},
+			},
+		},
+		{
+			...urlField,
+			required: true,
+			displayOptions: {
+				show: {
+					resource: [resource],
+					sessionMode: [SESSION_MODE.NEW],
+				},
+			},
+		},
+		{
+			...profileNameField,
+			displayOptions: {
+				show: {
+					resource: [resource],
+					sessionMode: [SESSION_MODE.NEW],
+				},
+			},
+		},
+		{
+			displayName: 'Auto-Terminate Session',
+			name: 'autoTerminateSession',
+			type: 'boolean',
+			default: true,
+			description: 'Whether to terminate the session after the operation is complete',
+			displayOptions: {
+				show: {
+					resource: [resource],
+					sessionMode: [SESSION_MODE.NEW],
+				},
+			},
+		},
+	];
+}

--- a/packages/nodes-base/nodes/Airtop/actions/common/session.utils.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/common/session.utils.ts
@@ -1,0 +1,45 @@
+import type { INodeExecutionData, IExecuteFunctions, IDataObject } from 'n8n-workflow';
+
+import {
+	validateSessionAndWindowId,
+	createSessionAndWindow,
+	shouldCreateNewSession,
+	validateAirtopApiResponse,
+} from '../../GenericFunctions';
+import { apiRequest } from '../../transport';
+
+/**
+ * Execute the node operation. Creates and terminates a new session if needed.
+ * @param this - The execution context
+ * @param index - The index of the node
+ * @param request - The request to execute
+ * @returns The response from the request
+ */
+export async function executeRequestWithSessionManagement(
+	this: IExecuteFunctions,
+	index: number,
+	request: {
+		method: 'POST' | 'DELETE';
+		path: string;
+		body: IDataObject;
+	},
+): Promise<INodeExecutionData[]> {
+	const { sessionId, windowId } = shouldCreateNewSession.call(this, index)
+		? await createSessionAndWindow.call(this, index)
+		: validateSessionAndWindowId.call(this, index);
+
+	const shouldTerminateSession = this.getNodeParameter('autoTerminateSession', index, false);
+
+	const endpoint = request.path.replace('{sessionId}', sessionId).replace('{windowId}', windowId);
+	const response = await apiRequest.call(this, request.method, endpoint, request.body);
+
+	validateAirtopApiResponse(this.getNode(), response);
+
+	if (shouldTerminateSession) {
+		await apiRequest.call(this, 'DELETE', `/sessions/${sessionId}`);
+		this.logger.info(`[${this.getNode().name}] Session terminated.`);
+		return this.helpers.returnJsonArray({ ...response });
+	}
+
+	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+}

--- a/packages/nodes-base/nodes/Airtop/actions/extraction/Extraction.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/extraction/Extraction.resource.ts
@@ -3,6 +3,7 @@ import type { INodeProperties } from 'n8n-workflow';
 import * as getPaginated from './getPaginated.operation';
 import * as query from './query.operation';
 import * as scrape from './scrape.operation';
+import { getSessionModeFields } from '../common/fields';
 
 export { getPaginated, query, scrape };
 
@@ -39,7 +40,7 @@ export const description: INodeProperties[] = [
 		],
 		default: 'getPaginated',
 	},
+	...getSessionModeFields('extraction', ['getPaginated', 'query', 'scrape']),
 	...getPaginated.description,
 	...query.description,
-	...scrape.description,
 ];

--- a/packages/nodes-base/nodes/Airtop/actions/extraction/scrape.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/extraction/scrape.operation.ts
@@ -1,58 +1,14 @@
-import {
-	type IExecuteFunctions,
-	type INodeExecutionData,
-	type INodeProperties,
-} from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
-import { validateSessionAndWindowId, validateAirtopApiResponse } from '../../GenericFunctions';
-import { apiRequest } from '../../transport';
-
-export const description: INodeProperties[] = [
-	{
-		displayName: 'Session ID',
-		name: 'sessionId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["sessionId"] }}',
-		displayOptions: {
-			show: {
-				resource: ['extraction'],
-				operation: ['scrape'],
-			},
-		},
-		description: 'The ID of the session to use for the scraping',
-	},
-	{
-		displayName: 'Window ID',
-		name: 'windowId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["windowId"] }}',
-		displayOptions: {
-			show: {
-				resource: ['extraction'],
-				operation: ['scrape'],
-			},
-		},
-		description: 'The ID of the window to use for the scraping',
-	},
-];
+import { executeRequestWithSessionManagement } from '../common/session.utils';
 
 export async function execute(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
-	const { sessionId, windowId } = validateSessionAndWindowId.call(this, index);
-
-	const response = await apiRequest.call(
-		this,
-		'POST',
-		`/sessions/${sessionId}/windows/${windowId}/scrape-content`,
-		{},
-	);
-
-	// validate response
-	validateAirtopApiResponse(this.getNode(), response);
-
-	return this.helpers.returnJsonArray({ sessionId, windowId, ...response });
+	return await executeRequestWithSessionManagement.call(this, index, {
+		method: 'POST',
+		path: '/sessions/{sessionId}/windows/{windowId}/scrape-content',
+		body: {},
+	});
 }

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/Interaction.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/Interaction.resource.ts
@@ -3,7 +3,7 @@ import type { INodeProperties } from 'n8n-workflow';
 import * as click from './click.operation';
 import * as hover from './hover.operation';
 import * as type from './type.operation';
-
+import { sessionIdField, windowIdField } from '../common/fields';
 export { click, hover, type };
 
 export const description: INodeProperties[] = [
@@ -40,25 +40,15 @@ export const description: INodeProperties[] = [
 		default: 'click',
 	},
 	{
-		displayName: 'Session ID',
-		name: 'sessionId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["sessionId"] }}',
+		...sessionIdField,
 		displayOptions: {
 			show: {
 				resource: ['interaction'],
 			},
 		},
-		description: 'The ID of the session to use for the interaction',
 	},
 	{
-		displayName: 'Window ID',
-		name: 'windowId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["windowId"] }}',
-		description: 'The ID of the window to use for the interaction',
+		...windowIdField,
 		displayOptions: {
 			show: {
 				resource: ['interaction'],

--- a/packages/nodes-base/nodes/Airtop/actions/session/terminate.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/session/terminate.operation.ts
@@ -7,21 +7,17 @@ import {
 
 import { validateAirtopApiResponse, validateSessionId } from '../../GenericFunctions';
 import { apiRequest } from '../../transport';
+import { sessionIdField } from '../common/fields';
 
 export const description: INodeProperties[] = [
 	{
-		displayName: 'Session ID',
-		name: 'sessionId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["sessionId"] }}',
+		...sessionIdField,
 		displayOptions: {
 			show: {
 				resource: ['session'],
 				operation: ['terminate'],
 			},
 		},
-		description: 'The ID of the session to terminate',
 	},
 ];
 

--- a/packages/nodes-base/nodes/Airtop/actions/window/Window.resource.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/Window.resource.ts
@@ -4,6 +4,7 @@ import * as close from './close.operation';
 import * as create from './create.operation';
 import * as getScreenshot from './getScreenshot.operation';
 import * as load from './load.operation';
+import { sessionIdField, windowIdField } from '../common/fields';
 
 export { create, close, getScreenshot, load };
 
@@ -47,20 +48,22 @@ export const description: INodeProperties[] = [
 		default: 'create',
 	},
 	{
-		displayName: 'Session ID',
-		name: 'sessionId',
-		type: 'string',
-		required: true,
+		...sessionIdField,
 		displayOptions: {
 			show: {
 				resource: ['window'],
 			},
 		},
-		default: '={{ $json["sessionId"] }}',
-		description: 'The ID of the session',
 	},
-	...close.description,
+	{
+		...windowIdField,
+		displayOptions: {
+			show: {
+				resource: ['window'],
+				operation: ['close', 'getScreenshot', 'load'],
+			},
+		},
+	},
 	...create.description,
-	...getScreenshot.description,
 	...load.description,
 ];

--- a/packages/nodes-base/nodes/Airtop/actions/window/close.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/close.operation.ts
@@ -1,24 +1,7 @@
-import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
 import { validateAirtopApiResponse, validateSessionAndWindowId } from '../../GenericFunctions';
 import { apiRequest } from '../../transport';
-
-export const description: INodeProperties[] = [
-	{
-		displayName: 'Window ID',
-		name: 'windowId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["windowId"] }}',
-		displayOptions: {
-			show: {
-				resource: ['window'],
-				operation: ['close'],
-			},
-		},
-		description: 'The ID of the window to close',
-	},
-];
 
 export async function execute(
 	this: IExecuteFunctions,

--- a/packages/nodes-base/nodes/Airtop/actions/window/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/create.operation.ts
@@ -9,15 +9,11 @@ import { NodeApiError } from 'n8n-workflow';
 import { validateAirtopApiResponse, validateSessionId, validateUrl } from '../../GenericFunctions';
 import { apiRequest } from '../../transport';
 import type { IAirtopResponse } from '../../transport/types';
+import { urlField } from '../common/fields';
 
 export const description: INodeProperties[] = [
 	{
-		displayName: 'URL',
-		name: 'url',
-		type: 'string',
-		default: '',
-		placeholder: 'https://google.com',
-		description: 'Initial URL to load in the window. Defaults to http://google.com.',
+		...urlField,
 		displayOptions: {
 			show: {
 				resource: ['window'],

--- a/packages/nodes-base/nodes/Airtop/actions/window/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/create.operation.ts
@@ -14,6 +14,7 @@ import { urlField } from '../common/fields';
 export const description: INodeProperties[] = [
 	{
 		...urlField,
+		description: 'Initial URL to load in the window. Defaults to http://google.com.',
 		displayOptions: {
 			show: {
 				resource: ['window'],

--- a/packages/nodes-base/nodes/Airtop/actions/window/getScreenshot.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/getScreenshot.operation.ts
@@ -1,27 +1,7 @@
-import {
-	type IExecuteFunctions,
-	type INodeExecutionData,
-	type INodeProperties,
-} from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
 import { validateSessionAndWindowId, validateAirtopApiResponse } from '../../GenericFunctions';
 import { apiRequest } from '../../transport';
-
-export const description: INodeProperties[] = [
-	{
-		displayName: 'Window ID',
-		name: 'windowId',
-		type: 'string',
-		required: true,
-		default: '={{ $json["windowId"] }}',
-		displayOptions: {
-			show: {
-				resource: ['window'],
-				operation: ['getScreenshot'],
-			},
-		},
-	},
-];
 
 export async function execute(
 	this: IExecuteFunctions,

--- a/packages/nodes-base/nodes/Airtop/actions/window/load.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/load.operation.ts
@@ -11,35 +11,18 @@ import {
 	validateAirtopApiResponse,
 } from '../../GenericFunctions';
 import { apiRequest } from '../../transport';
+import { urlField } from '../common/fields';
 
 export const description: INodeProperties[] = [
 	{
-		displayName: 'Window ID',
-		name: 'windowId',
-		type: 'string',
+		...urlField,
 		required: true,
-		default: '={{ $json["windowId"] }}',
 		displayOptions: {
 			show: {
 				resource: ['window'],
 				operation: ['load'],
 			},
 		},
-	},
-	{
-		displayName: 'URL',
-		name: 'url',
-		type: 'string',
-		required: true,
-		default: '',
-		placeholder: 'https://google.com',
-		displayOptions: {
-			show: {
-				resource: ['window'],
-				operation: ['load'],
-			},
-		},
-		description: 'The URL to load in the window',
 	},
 	{
 		displayName: 'Additional Fields',

--- a/packages/nodes-base/nodes/Airtop/test/node/extraction/query.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/extraction/query.test.ts
@@ -2,14 +2,16 @@ import nock from 'nock';
 
 import * as query from '../../../actions/extraction/query.operation';
 import { ERROR_MESSAGES } from '../../../constants';
+import * as GenericFunctions from '../../../GenericFunctions';
 import * as transport from '../../../transport';
 import { createMockExecuteFunction } from '../helpers';
 
 const baseNodeParameters = {
-	resource: 'window',
+	resource: 'extraction',
 	operation: 'query',
 	sessionId: 'test-session-123',
 	windowId: 'win-123',
+	sessionMode: 'existing',
 };
 
 const mockResponse = {
@@ -27,8 +29,28 @@ jest.mock('../../../transport', () => {
 	const originalModule = jest.requireActual<typeof transport>('../../../transport');
 	return {
 		...originalModule,
-		apiRequest: jest.fn(async function () {
+		apiRequest: jest.fn(async function (method: string, endpoint: string) {
+			if (method === 'DELETE' && endpoint.includes('/sessions/')) {
+				return { status: 'success' };
+			}
 			return mockResponse;
+		}),
+	};
+});
+
+jest.mock('../../../GenericFunctions', () => {
+	const originalModule = jest.requireActual<typeof GenericFunctions>('../../../GenericFunctions');
+	return {
+		...originalModule,
+		createSessionAndWindow: jest.fn().mockImplementation(async () => {
+			return {
+				sessionId: 'new-session-456',
+				windowId: 'new-win-456',
+			};
+		}),
+		shouldCreateNewSession: jest.fn().mockImplementation(function (this: any) {
+			const sessionMode = this.getNodeParameter('sessionMode', 0);
+			return sessionMode === 'new';
 		}),
 	};
 });
@@ -41,13 +63,14 @@ describe('Test Airtop, query page operation', () => {
 	afterAll(() => {
 		nock.restore();
 		jest.unmock('../../../transport');
+		jest.unmock('../../../GenericFunctions');
 	});
 
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
 
-	it('should query page with minimal parameters', async () => {
+	it('should query page with minimal parameters using existing session', async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			prompt: 'How many products are on the page and what is their price range?',
@@ -55,6 +78,8 @@ describe('Test Airtop, query page operation', () => {
 
 		const result = await query.execute.call(createMockExecuteFunction(nodeParameters), 0);
 
+		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
+		expect(GenericFunctions.createSessionAndWindow).not.toHaveBeenCalled();
 		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
 		expect(transport.apiRequest).toHaveBeenCalledWith(
 			'POST',
@@ -76,7 +101,7 @@ describe('Test Airtop, query page operation', () => {
 		]);
 	});
 
-	it('should query page with output schema', async () => {
+	it('should query page with output schema using existing session', async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			prompt: 'How many products are on the page and what is their price range?',
@@ -87,6 +112,8 @@ describe('Test Airtop, query page operation', () => {
 
 		const result = await query.execute.call(createMockExecuteFunction(nodeParameters), 0);
 
+		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
+		expect(GenericFunctions.createSessionAndWindow).not.toHaveBeenCalled();
 		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
 		expect(transport.apiRequest).toHaveBeenCalledWith(
 			'POST',
@@ -110,7 +137,40 @@ describe('Test Airtop, query page operation', () => {
 		]);
 	});
 
-	it('should throw error when sessionId is empty', async () => {
+	it('should query page using a new session', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			sessionMode: 'new',
+			url: 'https://example.com',
+			prompt: 'How many products are on the page and what is their price range?',
+		};
+
+		const result = await query.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
+		expect(GenericFunctions.createSessionAndWindow).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1); // One for query, one for session deletion
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/new-session-456/windows/new-win-456/page-query',
+			{
+				prompt: 'How many products are on the page and what is their price range?',
+				configuration: {},
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: 'new-session-456',
+					windowId: 'new-win-456',
+					data: mockResponse.data,
+				},
+			},
+		]);
+	});
+
+	it("should throw error when 'sessionId' is empty in 'existing' session mode", async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			sessionId: '',
@@ -122,7 +182,7 @@ describe('Test Airtop, query page operation', () => {
 		);
 	});
 
-	it('should throw error when windowId is empty', async () => {
+	it("should throw error when 'windowId' is empty in 'existing' session mode", async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			windowId: '',

--- a/packages/nodes-base/nodes/Airtop/test/node/extraction/query.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/extraction/query.test.ts
@@ -70,7 +70,7 @@ describe('Test Airtop, query page operation', () => {
 		jest.clearAllMocks();
 	});
 
-	it('should query page with minimal parameters using existing session', async () => {
+	it('should query the page with minimal parameters using existing session', async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			prompt: 'How many products are on the page and what is their price range?',
@@ -101,7 +101,7 @@ describe('Test Airtop, query page operation', () => {
 		]);
 	});
 
-	it('should query page with output schema using existing session', async () => {
+	it('should query the page with output schema using existing session', async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			prompt: 'How many products are on the page and what is their price range?',
@@ -137,20 +137,22 @@ describe('Test Airtop, query page operation', () => {
 		]);
 	});
 
-	it('should query page using a new session', async () => {
+	it('should query the page using a new session', async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			sessionMode: 'new',
 			url: 'https://example.com',
 			prompt: 'How many products are on the page and what is their price range?',
+			autoTerminateSession: true,
 		};
 
 		const result = await query.execute.call(createMockExecuteFunction(nodeParameters), 0);
 
 		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
 		expect(GenericFunctions.createSessionAndWindow).toHaveBeenCalledTimes(1);
-		expect(transport.apiRequest).toHaveBeenCalledTimes(1); // One for query, one for session deletion
-		expect(transport.apiRequest).toHaveBeenCalledWith(
+		expect(transport.apiRequest).toHaveBeenCalledTimes(2); // One for query, one for session deletion
+		expect(transport.apiRequest).toHaveBeenNthCalledWith(
+			1,
 			'POST',
 			'/sessions/new-session-456/windows/new-win-456/page-query',
 			{
@@ -162,8 +164,6 @@ describe('Test Airtop, query page operation', () => {
 		expect(result).toEqual([
 			{
 				json: {
-					sessionId: 'new-session-456',
-					windowId: 'new-win-456',
 					data: mockResponse.data,
 				},
 			},

--- a/packages/nodes-base/nodes/Airtop/test/node/extraction/scrape.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/extraction/scrape.test.ts
@@ -124,14 +124,16 @@ describe('Test Airtop, scrape operation', () => {
 			...baseNodeParameters,
 			sessionMode: 'new',
 			url: 'https://example.com',
+			autoTerminateSession: true,
 		};
 
 		const result = await scrape.execute.call(createMockExecuteFunction(nodeParameters), 0);
 
 		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
 		expect(GenericFunctions.createSessionAndWindow).toHaveBeenCalledTimes(1);
-		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
-		expect(transport.apiRequest).toHaveBeenCalledWith(
+		expect(transport.apiRequest).toHaveBeenCalledTimes(2); // One for scrape, one for session deletion
+		expect(transport.apiRequest).toHaveBeenNthCalledWith(
+			1,
 			'POST',
 			'/sessions/new-session-456/windows/new-win-456/scrape-content',
 			{},
@@ -140,8 +142,6 @@ describe('Test Airtop, scrape operation', () => {
 		expect(result).toEqual([
 			{
 				json: {
-					sessionId: 'new-session-456',
-					windowId: 'new-win-456',
 					data: mockResponse.data,
 				},
 			},

--- a/packages/nodes-base/nodes/Airtop/test/node/extraction/scrape.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/extraction/scrape.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock';
 
 import * as scrape from '../../../actions/extraction/scrape.operation';
 import { ERROR_MESSAGES } from '../../../constants';
+import * as GenericFunctions from '../../../GenericFunctions';
 import * as transport from '../../../transport';
 import { createMockExecuteFunction } from '../helpers';
 
@@ -10,6 +11,7 @@ const baseNodeParameters = {
 	operation: 'scrape',
 	sessionId: 'test-session-123',
 	windowId: 'win-123',
+	sessionMode: 'existing',
 };
 
 const mockResponse = {
@@ -22,11 +24,28 @@ jest.mock('../../../transport', () => {
 	const originalModule = jest.requireActual<typeof transport>('../../../transport');
 	return {
 		...originalModule,
-		apiRequest: jest.fn(async function () {
+		apiRequest: jest.fn(async function (method: string, endpoint: string) {
+			if (method === 'DELETE' && endpoint.includes('/sessions/')) {
+				return { status: 'success' };
+			}
+			return mockResponse;
+		}),
+	};
+});
+
+jest.mock('../../../GenericFunctions', () => {
+	const originalModule = jest.requireActual<typeof GenericFunctions>('../../../GenericFunctions');
+	return {
+		...originalModule,
+		createSessionAndWindow: jest.fn().mockImplementation(async () => {
 			return {
-				status: 'success',
-				data: mockResponse.data,
+				sessionId: 'new-session-456',
+				windowId: 'new-win-456',
 			};
+		}),
+		shouldCreateNewSession: jest.fn().mockImplementation(function (this: any) {
+			const sessionMode = this.getNodeParameter('sessionMode', 0);
+			return sessionMode === 'new';
 		}),
 	};
 });
@@ -39,15 +58,18 @@ describe('Test Airtop, scrape operation', () => {
 	afterAll(() => {
 		nock.restore();
 		jest.unmock('../../../transport');
+		jest.unmock('../../../GenericFunctions');
 	});
 
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
 
-	it('should scrape content successfully', async () => {
+	it('should scrape content with minimal parameters using existing session', async () => {
 		const result = await scrape.execute.call(createMockExecuteFunction(baseNodeParameters), 0);
 
+		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
+		expect(GenericFunctions.createSessionAndWindow).not.toHaveBeenCalled();
 		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
 		expect(transport.apiRequest).toHaveBeenCalledWith(
 			'POST',
@@ -60,14 +82,73 @@ describe('Test Airtop, scrape operation', () => {
 				json: {
 					sessionId: 'test-session-123',
 					windowId: 'win-123',
-					status: 'success',
 					data: mockResponse.data,
 				},
 			},
 		]);
 	});
 
-	it('should throw error when sessionId is empty', async () => {
+	it('should scrape content with additional parameters using existing session', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			additionalFields: {
+				waitForSelector: '.product-list',
+				waitForTimeout: 5000,
+			},
+		};
+
+		const result = await scrape.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
+		expect(GenericFunctions.createSessionAndWindow).not.toHaveBeenCalled();
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/scrape-content',
+			{},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: 'test-session-123',
+					windowId: 'win-123',
+					data: mockResponse.data,
+				},
+			},
+		]);
+	});
+
+	it('should scrape content using a new session', async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			sessionMode: 'new',
+			url: 'https://example.com',
+		};
+
+		const result = await scrape.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(GenericFunctions.shouldCreateNewSession).toHaveBeenCalledTimes(1);
+		expect(GenericFunctions.createSessionAndWindow).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/new-session-456/windows/new-win-456/scrape-content',
+			{},
+		);
+
+		expect(result).toEqual([
+			{
+				json: {
+					sessionId: 'new-session-456',
+					windowId: 'new-win-456',
+					data: mockResponse.data,
+				},
+			},
+		]);
+	});
+
+	it("should throw error when sessionId is empty in 'existing' session mode", async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			sessionId: '',
@@ -78,7 +159,7 @@ describe('Test Airtop, scrape operation', () => {
 		);
 	});
 
-	it('should throw error when windowId is empty', async () => {
+	it("should throw error when windowId is empty in 'existing' session mode", async () => {
 		const nodeParameters = {
 			...baseNodeParameters,
 			windowId: '',

--- a/packages/nodes-base/nodes/Airtop/test/node/helpers.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/helpers.ts
@@ -41,6 +41,9 @@ export const createMockExecuteFunction = (nodeParameters: IDataObject) => {
 			},
 		},
 		continueOnFail: () => false,
+		logger: {
+			info: () => {},
+		},
 	} as unknown as IExecuteFunctions;
 	return fakeExecuteFunction;
 };

--- a/packages/nodes-base/nodes/Airtop/test/node/window/create.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/window/create.test.ts
@@ -122,7 +122,6 @@ describe('Test Airtop, window create operation', () => {
 			...baseNodeParameters,
 			getLiveView: true,
 			disableResize: true,
-			additionalFields: {},
 		};
 
 		const result = await create.execute.call(createMockExecuteFunction(nodeParameters), 0);

--- a/packages/nodes-base/nodes/Airtop/test/session-utils.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/session-utils.test.ts
@@ -1,0 +1,201 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { createMockExecuteFunction } from './node/helpers';
+import { SESSION_MODE } from '../actions/common/fields';
+import { executeRequestWithSessionManagement } from '../actions/common/session.utils';
+import * as transport from '../transport';
+
+jest.mock('../transport', () => {
+	const originalModule = jest.requireActual<typeof transport>('../transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async () => {
+			return {
+				success: true,
+			};
+		}),
+	};
+});
+
+jest.mock('../GenericFunctions', () => ({
+	shouldCreateNewSession: jest.fn(function (this: IExecuteFunctions, index: number) {
+		const sessionMode = this.getNodeParameter('sessionMode', index);
+		return sessionMode === SESSION_MODE.NEW;
+	}),
+	createSessionAndWindow: jest.fn(async () => ({
+		sessionId: 'new-session-123',
+		windowId: 'new-window-123',
+	})),
+	validateSessionAndWindowId: jest.fn(() => ({
+		sessionId: 'existing-session-123',
+		windowId: 'existing-window-123',
+	})),
+	validateAirtopApiResponse: jest.fn(),
+}));
+
+describe('executeRequestWithSessionManagement', () => {
+	afterAll(() => {
+		jest.unmock('../transport');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe("When 'sessionMode' is 'new'", () => {
+		it("should create a new session and window when 'sessionMode' is 'new'", async () => {
+			const nodeParameters = {
+				sessionMode: SESSION_MODE.NEW,
+				url: 'https://example.com',
+				autoTerminateSession: true,
+			};
+
+			const result = await executeRequestWithSessionManagement.call(
+				createMockExecuteFunction(nodeParameters),
+				0,
+				{
+					method: 'POST',
+					path: '/sessions/{sessionId}/windows/{windowId}/action',
+					body: {},
+				},
+			);
+
+			expect(result).toEqual([
+				{
+					json: {
+						success: true,
+					},
+				},
+			]);
+		});
+
+		it("should not terminate session when 'autoTerminateSession' is false", async () => {
+			const nodeParameters = {
+				sessionMode: SESSION_MODE.NEW,
+				url: 'https://example.com',
+				autoTerminateSession: false,
+			};
+
+			const result = await executeRequestWithSessionManagement.call(
+				createMockExecuteFunction(nodeParameters),
+				0,
+				{
+					method: 'POST',
+					path: '/sessions/{sessionId}/windows/{windowId}/action',
+					body: {},
+				},
+			);
+
+			expect(transport.apiRequest).not.toHaveBeenCalledWith(
+				'DELETE',
+				'/sessions/existing-session-123',
+			);
+
+			expect(result).toEqual([
+				{
+					json: {
+						sessionId: 'new-session-123',
+						windowId: 'new-window-123',
+						success: true,
+					},
+				},
+			]);
+		});
+
+		it("should terminate session when 'autoTerminateSession' is true", async () => {
+			const nodeParameters = {
+				sessionMode: SESSION_MODE.NEW,
+				url: 'https://example.com',
+				autoTerminateSession: true,
+			};
+
+			await executeRequestWithSessionManagement.call(createMockExecuteFunction(nodeParameters), 0, {
+				method: 'POST',
+				path: '/sessions/{sessionId}/windows/{windowId}/action',
+				body: {},
+			});
+
+			expect(transport.apiRequest).toHaveBeenNthCalledWith(
+				2,
+				'DELETE',
+				'/sessions/new-session-123',
+			);
+		});
+
+		it("should call the operation passed in the 'request' parameter", async () => {
+			const nodeParameters = {
+				sessionMode: SESSION_MODE.NEW,
+				url: 'https://example.com',
+				autoTerminateSession: true,
+			};
+
+			await executeRequestWithSessionManagement.call(createMockExecuteFunction(nodeParameters), 0, {
+				method: 'POST',
+				path: '/sessions/{sessionId}/windows/{windowId}/action',
+				body: {
+					operation: 'test-operation',
+				},
+			});
+
+			expect(transport.apiRequest).toHaveBeenNthCalledWith(
+				1,
+				'POST',
+				'/sessions/new-session-123/windows/new-window-123/action',
+				{
+					operation: 'test-operation',
+				},
+			);
+		});
+	});
+
+	describe("When 'sessionMode' is 'existing'", () => {
+		it('should not create a new session and window', async () => {
+			const nodeParameters = {
+				sessionMode: SESSION_MODE.EXISTING,
+				url: 'https://example.com',
+				sessionId: 'existing-session-123',
+				windowId: 'existing-window-123',
+			};
+
+			await executeRequestWithSessionManagement.call(createMockExecuteFunction(nodeParameters), 0, {
+				method: 'POST',
+				path: '/sessions/{sessionId}/windows/{windowId}/action',
+				body: {},
+			});
+
+			expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+
+			expect(transport.apiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/sessions/existing-session-123/windows/existing-window-123/action',
+				{},
+			);
+		});
+
+		it("should call the operation passed in the 'request' parameter", async () => {
+			const nodeParameters = {
+				sessionMode: SESSION_MODE.EXISTING,
+				url: 'https://example.com',
+				sessionId: 'existing-session-123',
+				windowId: 'existing-window-123',
+			};
+
+			await executeRequestWithSessionManagement.call(createMockExecuteFunction(nodeParameters), 0, {
+				method: 'POST',
+				path: '/sessions/{sessionId}/windows/{windowId}/action',
+				body: {
+					operation: 'test-operation',
+				},
+			});
+
+			expect(transport.apiRequest).toHaveBeenNthCalledWith(
+				1,
+				'POST',
+				'/sessions/existing-session-123/windows/existing-window-123/action',
+				{
+					operation: 'test-operation',
+				},
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add support for creating sessions automatically in Extraction opeations

<img width="741" alt="image" src="https://github.com/user-attachments/assets/bf95928b-06dc-49fe-ad77-bd8fff293af7" />
 

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
