### PR TITLE
feat(Airtop Node): Default to binary output for screenshots

### DIFF
--- a/packages/nodes-base/nodes/Airtop/actions/window/takeScreenshot.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/takeScreenshot.operation.ts
@@ -18,7 +18,7 @@ export const description: INodeProperties[] = [
 		description: 'Whether to output the image as a binary file instead of a base64 encoded string',
 		name: 'outputImageAsBinary',
 		type: 'boolean',
-		default: false,
+		default: true,
 		displayOptions: {
 			show: {
 				resource: ['window'],


### PR DESCRIPTION
## Summary

Return binary output from Screenshot operations.

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
