### PR TITLE
feat(Airtop Node): Implement double-click and right-click variants

### DIFF
--- a/packages/nodes-base/credentials/AirtopApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtopApi.credentials.ts
@@ -28,29 +28,6 @@ export class AirtopApi implements ICredentialType {
 			},
 			noDataExpression: true,
 		},
-		{
-			displayName: 'Custom API',
-			name: 'customApi',
-			type: 'boolean',
-			default: false,
-			noDataExpression: true,
-			description:
-				'Whether to change the default URL for the API. Only enable this if you are using a custom Airtop instance.',
-		},
-		{
-			displayName: 'API URL',
-			name: 'apiUrl',
-			type: 'string',
-			default: '',
-			description: 'The base URL for the Airtop API. Leave empty to use the default.',
-			placeholder: 'https://api.airtop.ai/api/v1',
-			noDataExpression: true,
-			displayOptions: {
-				show: {
-					customApi: [true],
-				},
-			},
-		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -66,7 +43,7 @@ export class AirtopApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			method: 'GET',
-			baseURL: '={{$credentials.apiUrl || "' + BASE_URL + '"}}',
+			baseURL: BASE_URL,
 			url: '/sessions',
 			qs: {
 				limit: 10,

--- a/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtop/GenericFunctions.ts
@@ -24,7 +24,6 @@ import type {
 	IAirtopResponse,
 	IAirtopServerEvent,
 	IAirtopSessionResponse,
-	IAirtopApiCredentials,
 } from './transport/types';
 
 /**
@@ -499,8 +498,7 @@ export async function waitForSessionEvent(
 	condition: (event: IAirtopServerEvent) => boolean,
 	timeoutInSeconds = DEFAULT_DOWNLOAD_TIMEOUT_SECONDS,
 ): Promise<IAirtopServerEvent> {
-	const { apiUrl } = await this.getCredentials<IAirtopApiCredentials>('airtopApi');
-	const url = `${apiUrl || BASE_URL}/sessions/${sessionId}/events?all=true`;
+	const url = `${BASE_URL}/sessions/${sessionId}/events?all=true`;
 	let stream: Stream;
 
 	const eventPromise = new Promise<IAirtopServerEvent>(async (resolve) => {

--- a/packages/nodes-base/nodes/Airtop/actions/file/helpers.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/file/helpers.ts
@@ -1,8 +1,8 @@
 import pick from 'lodash/pick';
-import type { IExecuteFunctions, IHttpRequestMethods } from 'n8n-workflow';
+import type { IExecuteFunctions } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
-import { ERROR_MESSAGES, OPERATION_TIMEOUT } from '../../constants';
+import { BASE_URL, ERROR_MESSAGES, OPERATION_TIMEOUT } from '../../constants';
 import { apiRequest } from '../../transport';
 import type { IAirtopResponseWithFiles, IAirtopFileInputRequest } from '../../transport/types';
 
@@ -147,12 +147,9 @@ export async function waitForFileInSession(
 	fileId: string,
 	timeout = OPERATION_TIMEOUT,
 ): Promise<void> {
+	const url = `${BASE_URL}/files/${fileId}`;
 	const isFileInSession = async (): Promise<boolean> => {
-		const fileInfo = await apiRequest.call<
-			IExecuteFunctions,
-			[IHttpRequestMethods, string],
-			Promise<IAirtopResponseWithFiles>
-		>(this, 'GET', `/files/${fileId}`);
+		const fileInfo = (await apiRequest.call(this, 'GET', url)) as IAirtopResponseWithFiles;
 		return Boolean(fileInfo.data?.sessionIds?.includes(sessionId));
 	};
 

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/click.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/click.operation.ts
@@ -25,6 +25,33 @@ export const description: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Click Type',
+		name: 'clickType',
+		type: 'options',
+		default: 'click',
+		description: 'The type of click to perform. Defaults to left click.',
+		options: [
+			{
+				name: 'Left Click',
+				value: 'click',
+			},
+			{
+				name: 'Double Click',
+				value: 'doubleClick',
+			},
+			{
+				name: 'Right Click',
+				value: 'rightClick',
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['interaction'],
+				operation: ['click'],
+			},
+		},
+	},
 ];
 
 export async function execute(
@@ -39,8 +66,13 @@ export async function execute(
 		'Element Description',
 	);
 
+	const clickType = validateRequiredStringField.call(this, index, 'clickType', 'Click Type');
+
 	const request = constructInteractionRequest.call(this, index, {
 		elementDescription,
+		configuration: {
+			clickType,
+		},
 	});
 
 	const response = await apiRequest.call(

--- a/packages/nodes-base/nodes/Airtop/actions/interaction/helpers.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/interaction/helpers.ts
@@ -9,7 +9,10 @@ export function constructInteractionRequest(
 ): IAirtopInteractionRequest {
 	const additionalFields = this.getNodeParameter('additionalFields', index);
 	const request: IAirtopInteractionRequest = {
-		configuration: {},
+		...parameters,
+		configuration: {
+			...(parameters.configuration ?? {}),
+		},
 	};
 
 	if (additionalFields.visualScope) {
@@ -24,8 +27,6 @@ export function constructInteractionRequest(
 			waitUntil: additionalFields.waitForNavigation as string,
 		};
 	}
-
-	Object.assign(request, parameters);
 
 	return request;
 }

--- a/packages/nodes-base/nodes/Airtop/test/node/file/helpers.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/file/helpers.test.ts
@@ -1,4 +1,5 @@
 import * as helpers from '../../../actions/file/helpers';
+import { BASE_URL } from '../../../constants';
 import * as transport from '../../../transport';
 import { createMockExecuteFunction } from '../helpers';
 
@@ -207,7 +208,7 @@ describe('Test Airtop file helpers', () => {
 			await helpers.waitForFileInSession.call(mockExecuteFunction, 'session-123', 'file-123', 1000);
 
 			expect(apiRequestMock).toHaveBeenCalledTimes(1);
-			expect(apiRequestMock).toHaveBeenCalledWith('GET', '/files/file-123');
+			expect(apiRequestMock).toHaveBeenCalledWith('GET', `${BASE_URL}/files/file-123`);
 		});
 
 		it('should timeout if file never becomes available in session', async () => {
@@ -247,7 +248,7 @@ describe('Test Airtop file helpers', () => {
 			await helpers.waitForFileInSession.call(mockExecuteFunction, 'session-123', 'file-123', 1000);
 
 			expect(apiRequestMock).toHaveBeenCalledTimes(1);
-			expect(apiRequestMock).toHaveBeenCalledWith('GET', '/files/file-123');
+			expect(apiRequestMock).toHaveBeenCalledWith('GET', `${BASE_URL}/files/file-123`);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Airtop/test/node/interaction/click.test.ts
+++ b/packages/nodes-base/nodes/Airtop/test/node/interaction/click.test.ts
@@ -11,6 +11,7 @@ const baseNodeParameters = {
 	sessionId: 'test-session-123',
 	windowId: 'win-123',
 	elementDescription: 'the login button',
+	clickType: 'click',
 	additionalFields: {},
 };
 
@@ -55,7 +56,9 @@ describe('Test Airtop, click operation', () => {
 			'/sessions/test-session-123/windows/win-123/click',
 			{
 				elementDescription: 'the login button',
-				configuration: {},
+				configuration: {
+					clickType: 'click',
+				},
 			},
 		);
 
@@ -104,6 +107,7 @@ describe('Test Airtop, click operation', () => {
 					visualAnalysis: {
 						scope: 'viewport',
 					},
+					clickType: 'click',
 				},
 				elementDescription: 'the login button',
 			},
@@ -125,12 +129,53 @@ describe('Test Airtop, click operation', () => {
 			'/sessions/test-session-123/windows/win-123/click',
 			{
 				configuration: {
+					clickType: 'click',
 					waitForNavigationConfig: {
 						waitUntil: 'load',
 					},
 				},
 				waitForNavigation: true,
 				elementDescription: 'the login button',
+			},
+		);
+	});
+
+	it("should execute double click when 'clickType' is 'doubleClick'", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			clickType: 'doubleClick',
+		};
+
+		await click.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/click',
+			{
+				elementDescription: 'the login button',
+				configuration: {
+					clickType: 'doubleClick',
+				},
+			},
+		);
+	});
+
+	it("should execute right click when 'clickType' is 'rightClick'", async () => {
+		const nodeParameters = {
+			...baseNodeParameters,
+			clickType: 'rightClick',
+		};
+
+		await click.execute.call(createMockExecuteFunction(nodeParameters), 0);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/sessions/test-session-123/windows/win-123/click',
+			{
+				elementDescription: 'the login button',
+				configuration: {
+					clickType: 'rightClick',
+				},
 			},
 		);
 	});

--- a/packages/nodes-base/nodes/Airtop/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtop/transport/index.ts
@@ -6,7 +6,7 @@ import type {
 	IHttpRequestOptions,
 } from 'n8n-workflow';
 
-import type { IAirtopApiCredentials, IAirtopResponse } from './types';
+import type { IAirtopResponse } from './types';
 import { BASE_URL, N8N_VERSION } from '../constants';
 
 const defaultHeaders = {
@@ -22,13 +22,12 @@ export async function apiRequest<T extends IAirtopResponse = IAirtopResponse>(
 	body: IDataObject = {},
 	query: IDataObject = {},
 ): Promise<T> {
-	const { apiUrl } = await this.getCredentials<IAirtopApiCredentials>('airtopApi');
 	const options: IHttpRequestOptions = {
 		headers: defaultHeaders,
 		method,
 		body,
 		qs: query,
-		url: `${apiUrl || BASE_URL}${endpoint}`,
+		url: `${BASE_URL}${endpoint}`,
 		json: true,
 	};
 

--- a/packages/nodes-base/nodes/Airtop/transport/types.ts
+++ b/packages/nodes-base/nodes/Airtop/transport/types.ts
@@ -1,8 +1,4 @@
-import type { ICredentialDataDecryptedObject, IDataObject, INodeExecutionData } from 'n8n-workflow';
-
-export interface IAirtopApiCredentials extends ICredentialDataDecryptedObject {
-	apiUrl: string;
-}
+import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
 
 export interface IAirtopSessionResponse extends IDataObject {
 	data: {
@@ -65,6 +61,7 @@ export interface IAirtopInteractionRequest extends IDataObject {
 		waitForNavigationConfig?: {
 			waitUntil: string;
 		};
+		clickType?: string;
 	};
 }
 


### PR DESCRIPTION
## Summary

Include click variants in node's operation:
- Double-click
- Right-click

<img width="534" height="734" alt="image" src="https://github.com/user-attachments/assets/eb710b35-c881-4053-85f2-2cc88bf5dfe3" />


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
