### PR TITLE
revert: feat(Airtop Node): Default to binary output for screenshots (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Airtop/actions/window/takeScreenshot.operation.ts
+++ b/packages/nodes-base/nodes/Airtop/actions/window/takeScreenshot.operation.ts
@@ -18,7 +18,7 @@ export const description: INodeProperties[] = [
 		description: 'Whether to output the image as a binary file instead of a base64 encoded string',
 		name: 'outputImageAsBinary',
 		type: 'boolean',
-		default: true,
+		default: false,
 		displayOptions: {
 			show: {
 				resource: ['window'],


### PR DESCRIPTION
## Summary

This reverts commit 01c1a82cc163109b8247f944f071e33f4dc40dde.
Restore previous default (base64 string) by setting outputImageAsBinary to false to avoid breaking existing workflows.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
